### PR TITLE
Don't leak compiler settings to other CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library (utf8proc
   utf8proc.h
 )
 
+target_include_directories(utf8proc PUBLIC ../utf8proc)
+
 set_target_properties(
   utf8proc PROPERTIES
   COMPILE_DEFINITIONS "UTF8PROC_EXPORTS"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,14 @@ set(SO_MAJOR 2)
 set(SO_MINOR 0)
 set(SO_PATCH 0)
 
-add_definitions (
-  -DUTF8PROC_EXPORTS
-)
-
 add_library (utf8proc
   utf8proc.c
   utf8proc.h
+)
+
+set_target_properties(
+  utf8proc PROPERTIES
+  COMPILE_DEFINITIONS "UTF8PROC_EXPORTS"
 )
 
 if (NOT MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,17 @@ add_definitions (
   -DUTF8PROC_EXPORTS
 )
 
-if (NOT MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -std=c99 -pedantic -Wall")
-endif ()
-
 add_library (utf8proc
   utf8proc.c
   utf8proc.h
 )
+
+if (NOT MSVC)
+  set_target_properties(
+    utf8proc PROPERTIES
+    COMPILE_FLAGS "-O2 -std=c99 -pedantic -Wall"
+  )
+endif ()
 
 set_target_properties (utf8proc PROPERTIES
   POSITION_INDEPENDENT_CODE ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8.11)
 
 include (utils.cmake)
 


### PR DESCRIPTION
It is a global property, which is not great when importing utf8proc in other CMake projects.
