### PR TITLE
[CMake] Add UTF8PROC_NO_INSTALL option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SO_MAJOR 2)
 set(SO_MINOR 2)
 set(SO_PATCH 0)
 
-option(UTF8PROC_NO_INSTALL "Disable installation of utf8proc" Off)
+option(UTF8PROC_INSTALL "Enable installation of utf8proc" On)
 
 add_library (utf8proc
   utf8proc.c
@@ -48,7 +48,7 @@ set_target_properties (utf8proc PROPERTIES
   SOVERSION ${SO_MAJOR}
 )
 
-if (NOT UTF8PROC_NO_INSTALL)
+if (UTF8PROC_INSTALL)
   install(TARGETS utf8proc
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SO_MAJOR 2)
 set(SO_MINOR 2)
 set(SO_PATCH 0)
 
+option(UTF8PROC_NO_INSTALL "Disable installation of utf8proc" Off)
+
 add_library (utf8proc
   utf8proc.c
   utf8proc.h
@@ -46,12 +48,14 @@ set_target_properties (utf8proc PROPERTIES
   SOVERSION ${SO_MAJOR}
 )
 
-install(TARGETS utf8proc
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
+if (NOT UTF8PROC_NO_INSTALL)
+  install(TARGETS utf8proc
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
 
-install(
-  FILES
-    "${PROJECT_SOURCE_DIR}/utf8proc.h"
-  DESTINATION include)
+  install(
+    FILES
+      "${PROJECT_SOURCE_DIR}/utf8proc.h"
+    DESTINATION include)
+endif()


### PR DESCRIPTION
In some cases (such as using the library via `add_subdirectory` in CMake), it may be desirable to disable installation.