### PR TITLE
Fix 2 excessive dependencies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ manifest: MANIFEST.new
 
 # real targets
 
-data/utf8proc_data.c.new: libutf8proc.$(SHLIB_EXT) data/data_generator.rb data/charwidths.jl
+data/utf8proc_data.c.new: libutf8proc.$(SHLIB_EXT) data/data_generator.rb
 	$(MAKE) -C data utf8proc_data.c.new
 
 utf8proc.o: utf8proc.h utf8proc.c utf8proc_data.c
@@ -88,7 +88,7 @@ libutf8proc.so: libutf8proc.so.$(MAJOR).$(MINOR).$(PATCH)
 	ln -f -s libutf8proc.so.$(MAJOR).$(MINOR).$(PATCH) $@
 	ln -f -s libutf8proc.so.$(MAJOR).$(MINOR).$(PATCH) $@.$(MAJOR)
 
-libutf8proc.$(MAJOR).dylib: utf8proc.o
+libutf8proc.$(MAJOR).dylib:
 	$(CC) $(LDFLAGS) -dynamiclib -o $@ $^ -install_name $(libdir)/$@ -Wl,-compatibility_version -Wl,$(MAJOR) -Wl,-current_version -Wl,$(MAJOR).$(MINOR).$(PATCH)
 
 libutf8proc.dylib: libutf8proc.$(MAJOR).dylib


### PR DESCRIPTION
Hi, I've fixed 2 excessive dependencies reported.
Those issues can cause unnecessary rebuilds when `utf8proc` is incrementally built.

For example, any changes in `data/charwidths.jl` will the unnecessary rebuild of `data/utf8proc_data.c.new`, which can slow down the build process of the total project.

I modify the Makefile to remove these excessive dependencies. I've checked and the new Makefile works well.
Looking forward to your confirmation.

Thanks
Vemake