### PR TITLE
Revert "disable tests under mingw"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,12 +29,14 @@ build_script:
       cd /c/projects/utf8proc &&
       mkdir mingw_static &&
       cd mingw_static &&
-      cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -G'MSYS Makefiles' &&
+      cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DUTF8PROC_ENABLE_TESTING=On -G'MSYS Makefiles' &&
       make &&
+      ctest &&
       mkdir ../mingw_shared &&
       cd ../mingw_shared &&
-      cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_SHARED_LIBS=ON -G'MSYS Makefiles' &&
-      make
+      cmake .. -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_SHARED_LIBS=ON -DUTF8PROC_ENABLE_TESTING=On -G'MSYS Makefiles' &&
+      make &&
+      ctest
       "
 
 on_finish:


### PR DESCRIPTION
This reverts commit 7e834d77024d770875559d853b09b8bb7f9321a1.

Hopefully these now work again after 11bb3d9dc796bb006c79c2962a7d19abcadfb3df and #188

Closes #186, if this was the source of the problem as suggested in https://github.com/JuliaStrings/utf8proc/pull/178#issuecomment-605615456