### PR TITLE
Unify include file handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library (utf8proc
 )
 
 # expose header path, for when this is part of a larger cmake project
-target_include_directories(utf8proc PUBLIC ../utf8proc)
+target_include_directories(utf8proc PUBLIC .)
 
 if (BUILD_SHARED_LIBS)
   # Building shared library


### PR DESCRIPTION
The cmake file expects the parent folder to be named "utf8proc",
otherwise the target_include_directories won't work, as it references
an unknown path.

This deviates from the install targets (both cmake and makefile) in
putting the include file into a subfolder in contrast to the top level
folder. This also prevents using the library with the recent cmake
addition of FetchContent.

This change unifies the include file handling by using the local path
for cmake as well.

This might break existing uses. As a workaround, we could add a dummy
include file in the old location (new utf8proc subfolder). I'm not sure
if that is necessary.