### PR TITLE
buildsys: cmake install .pc file for pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,15 +51,21 @@ set_target_properties (utf8proc PROPERTIES
 )
 
 if (UTF8PROC_INSTALL)
-  install(TARGETS utf8proc
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
+  include(GNUInstallDirs)
 
-  install(
-    FILES
-      "${PROJECT_SOURCE_DIR}/utf8proc.h"
-    DESTINATION include)
+  install(TARGETS utf8proc
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+  install(FILES utf8proc.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+  set(PREFIX     ${CMAKE_INSTALL_PREFIX})
+  set(LIBDIR     ${CMAKE_INSTALL_BINDIR})
+  set(INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
+  set(VERSION    2.6.1)
+  configure_file(libutf8proc.pc.in  libutf8proc.pc @ONLY)
+  install(FILES ${CMAKE_BINARY_DIR}/libutf8proc.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
 if(UTF8PROC_ENABLE_TESTING)

--- a/Makefile
+++ b/Makefile
@@ -96,11 +96,11 @@ libutf8proc.dylib: libutf8proc.$(MAJOR).dylib
 
 libutf8proc.pc: libutf8proc.pc.in
 	sed \
-		-e 's#PREFIX#$(prefix)#' \
-		-e 's#LIBDIR#$(pkglibdir)#' \
-		-e 's#INCLUDEDIR#$(pkgincludedir)#' \
-		-e 's#VERSION#$(MAJOR).$(MINOR).$(PATCH)#' \
-		libutf8proc.pc.in > libutf8proc.pc
+        -e 's#@PREFIX@#$(prefix)#' \
+        -e 's#@LIBDIR@#$(pkglibdir)#' \
+        -e 's#@INCLUDEDIR@#$(pkgincludedir)#' \
+        -e 's#@VERSION@#$(MAJOR).$(MINOR).$(PATCH)#' \
+        libutf8proc.pc.in > libutf8proc.pc
 
 install: libutf8proc.a libutf8proc.$(SHLIB_EXT) libutf8proc.$(SHLIB_VERS_EXT) libutf8proc.pc
 	mkdir -m 755 -p $(DESTDIR)$(includedir)

--- a/libutf8proc.pc.in
+++ b/libutf8proc.pc.in
@@ -1,10 +1,10 @@
-prefix=PREFIX
+prefix=@PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/LIBDIR
-includedir=${prefix}/INCLUDEDIR
+libdir=${prefix}/@LIBDIR@
+includedir=${prefix}/@INCLUDEDIR@
 
 Name: libutf8proc
 Description: UTF8 processing
-Version: VERSION
+Version: @VERSION@
 Libs: -L${libdir} -lutf8proc
 Cflags: -I${includedir} -DUTF8PROC_EXPORTS


### PR DESCRIPTION
modified `libutf8proc.pc.in`, changed from `PREFIX` to `@PREFIX@`, changed from `VERSION` to `@VERSION@`, beacuse `@VAR@` can be replaced by CMake's `configure_file` command.