### PR TITLE
[ci] set github CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,64 @@
+name: CMake
+
+on:
+  push:
+    branches:
+      - master
+      - 'release-*'
+  pull_request:
+  # run on all pr
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        shared: ["ON", "OFF"]
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} - shared=${{ matrix.shared }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: |
+        mkdir build
+        cmake -S . -B build -DBUILD_SHARED_LIBS=${{ matrix.shared }} -DUTF8PROC_ENABLE_TESTING=ON
+        cmake --build build
+    - name: Run Test
+      run: ctest --test-dir build -V
+    - name: Upload shared lib
+      if: matrix.shared == 'ON'
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.os }}
+        path: |
+          build/libutf8proc.*
+          build/Debug/utf8proc.*
+
+  mingw:
+    strategy:
+      matrix:
+        os: [windows-latest]
+        shared: ["ON", "OFF"]
+    runs-on: ${{ matrix.os }}
+    name: mingw64 - shared=${{ matrix.shared }}
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: msys2/setup-msys2@v2
+      with:
+        install: gcc make mingw-w64-x86_64-cmake
+    - name: Build
+      run: |
+        mkdir build
+        cmake -S . -B build -DBUILD_SHARED_LIBS=${{ matrix.shared }} -DUTF8PROC_ENABLE_TESTING=ON -G'MSYS Makefiles'
+        cmake --build build
+    - name: Run Test
+      run: ctest --test-dir build -V
+    - name: Upload shared lib
+      if: matrix.shared == 'ON'
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows-mingw64
+        path: build/libutf8proc.*

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -17,8 +17,13 @@ jobs:
     name: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+    # TODO: update makefile to check MANIFEST
+    # - name: Install dependencies (MacOS)
+    #   if: matrix.config.os == 'macos-latest'
+    #   run: brew install ruby findutils
 
     - name: Check MANIFEST
+      if: matrix.config.os == 'ubuntu-latest'
       run: make manifest && diff MANIFEST.new MANIFEST
     - name: Run Test
       run: make check

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,36 @@
+name: Make
+
+on:
+  push:
+    branches:
+      - master
+      - 'release-*'
+  pull_request:
+  # run on all pr
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Check MANIFEST
+      run: make manifest && diff MANIFEST.new MANIFEST
+    - name: Run Test
+      run: make check
+    - name: Check utf8proc_data.c
+      run: make data && diff data/utf8proc_data.c.new utf8proc_data.c
+    - name: Clean
+      run: make clean && git status --ignored --porcelain && test -z "$(git status --ignored --porcelain)"
+
+    - name: Make lib
+      run: make
+    - name: Upload shared lib
+      uses: actions/upload-artifact@v2
+      with:
+        name: make-${{ matrix.os }}
+        path: libutf8proc.*


### PR DESCRIPTION
Build on: ubuntu, windows, macOS, win+mingw64

Fix #206

We can add more combinations if needed, for example: ubuntu+mingw64, win+cygwin, *+clang.


Results of CI run: https://github.com/inkydragon/utf8proc/actions/runs/1324116342