### PR TITLE
version 2.9 bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ disallow_intree_builds()
 if (POLICY CMP0048)
   cmake_policy (SET CMP0048 NEW)
 endif ()
-project (utf8proc VERSION 2.8.0 LANGUAGES C)
+project (utf8proc VERSION 2.9.0 LANGUAGES C)
 
 # This is the ABI version number, which may differ from the
 # API version number (defined in utf8proc.h and above).
 # Be sure to also update these in Makefile and MANIFEST!
-set(SO_MAJOR 2)
-set(SO_MINOR 6)
+set(SO_MAJOR 3)
+set(SO_MINOR 0)
 set(SO_PATCH 0)
 
 option(UTF8PROC_INSTALL "Enable installation of utf8proc" On)

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,8 +2,8 @@ include/
 include/utf8proc.h
 lib/
 lib/libutf8proc.a
-lib/libutf8proc.so -> libutf8proc.so.2.6.0
-lib/libutf8proc.so.2 -> libutf8proc.so.2.6.0
-lib/libutf8proc.so.2.6.0
+lib/libutf8proc.so -> libutf8proc.so.3.0.0
+lib/libutf8proc.so.2 -> libutf8proc.so.3.0.0
+lib/libutf8proc.so.3.0.0
 lib/pkgconfig/
 lib/pkgconfig/libutf8proc.pc

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ SOFLAG = -Wl,-soname
 # compatibility is broken, even if the API is backward-compatible.
 # The API version number is defined in utf8proc.h.
 # Be sure to also update these ABI versions in MANIFEST and CMakeLists.txt!
-MAJOR=2
-MINOR=6
+MAJOR=3
+MINOR=0
 PATCH=0
 
 OS := $(shell uname)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # utf8proc release history #
 
+## Version 2.9.0 ##
+
+2023-10-20
+
+ - Unicode 15.1 support ([#253]).
+
 ## Version 2.8.0 ##
 
 2022-10-30
@@ -436,3 +442,4 @@ Release of version 1.0.1
 [#224]: https://github.com/JuliaStrings/utf8proc/issues/224
 [#233]: https://github.com/JuliaStrings/utf8proc/issues/233
 [#247]: https://github.com/JuliaStrings/utf8proc/issues/247
+[#253]: https://github.com/JuliaStrings/utf8proc/issues/253

--- a/utf8proc.h
+++ b/utf8proc.h
@@ -71,7 +71,7 @@
 /** The MAJOR version number (increased when backwards API compatibility is broken). */
 #define UTF8PROC_VERSION_MAJOR 2
 /** The MINOR version number (increased when new functionality is added in a backwards-compatible manner). */
-#define UTF8PROC_VERSION_MINOR 8
+#define UTF8PROC_VERSION_MINOR 9
 /** The PATCH version (increased for fixes that do not change the API). */
 #define UTF8PROC_VERSION_PATCH 0
 /** @} */


### PR DESCRIPTION
we can tag a new release once this is merged

note that the ABI version changed to 3.0 since the `utf8proc_property_t` struct definition changed, breaking ABI compatibility (albeit only for code that directly accesses this struct).