### PR TITLE
build: remove unnecessary policy check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@ include (utils.cmake)
 
 disallow_intree_builds()
 
-if (POLICY CMP0048)
-  cmake_policy (SET CMP0048 NEW)
-endif ()
 project (utf8proc VERSION 2.9.0 LANGUAGES C)
 
 # This is the ABI version number, which may differ from the


### PR DESCRIPTION
Minimum version is 3.5 and policy CMP0048 was introduced in 3.0, meaning
that it will always be set to `NEW`.
