### PR TITLE
document that utf8proc_map simply wraps utf8proc_decompose and utf8proc_reencode

### DIFF
--- a/utf8proc.h
+++ b/utf8proc.h
@@ -748,6 +748,10 @@ UTF8PROC_DLLEXPORT const char *utf8proc_category_string(utf8proc_int32_t codepoi
  *
  * @note The memory of the new UTF-8 string will have been allocated
  * with `malloc`, and should therefore be deallocated with `free`.
+ *
+ * @note `utf8proc_map` simply calls `utf8proc_decompose` followed by `utf8proc_reencode`,
+ * and applications requiring greater control over memory allocation should instead call
+ * those two functions directly.
  */
 UTF8PROC_DLLEXPORT utf8proc_ssize_t utf8proc_map(
   const utf8proc_uint8_t *str, utf8proc_ssize_t strlen, utf8proc_uint8_t **dstptr, utf8proc_option_t options


### PR DESCRIPTION
… and that the lower-level functions provide more control over memory allocation.  Closes #307.