### PR TITLE
Allow manually defining symbol visibility in static builds

### DIFF
--- a/utf8proc.h
+++ b/utf8proc.h
@@ -121,7 +121,9 @@ typedef bool utf8proc_bool;
 #include <limits.h>
 
 #ifdef UTF8PROC_STATIC
-#  define UTF8PROC_DLLEXPORT
+#  ifndef UTF8PROC_DLLEXPORT
+#    define UTF8PROC_DLLEXPORT
+#  endif
 #else
 #  ifdef _WIN32
 #    ifdef UTF8PROC_EXPORTS


### PR DESCRIPTION
I have a few build pipelines where I statically link utf8proc into a binary or other shared libs, but still need the symbols to be exported (e.g., plugins).

Because the CMake build system unconditionally defines UTF8PROC_STATIC, and there is no ifndef guard around UTF8PROC_DLLEXPORT, manually defining it with a flag is insufficient.

This PR just adds a small ifndef guard around the code block to allow manually defining `-DUTF8PROC_DLLEXPORT`.