### PR TITLE
Add missing CMake library alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library (utf8proc
   utf8proc.c
   utf8proc.h
 )
+add_library (utf8proc::utf8proc ALIAS utf8proc)
 
 # expose header path, for when this is part of a larger cmake project
 target_include_directories(utf8proc PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)


### PR DESCRIPTION
Without this, `target_link_libraries(${PROJECT_NAME} PRIVATE utf8proc::utf8proc)` only works with `find_package` and not with `add_subdirectory`. This is needed for `FetchContent` to work optimally.