### PR TITLE
Add uninstall target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ VERSION=2.11.3
 
 OS := $(shell uname)
 ifeq ($(OS),Darwin) # MacOS X
+  FIND=gfind
   SHLIB_EXT = dylib
   SHLIB_VERS_EXT = $(MAJOR).dylib
 else # GNU/Linux, at least (Windows should probably use cmake)
@@ -49,7 +50,7 @@ pkgincludedir=$(includedir:$(prefix)/%=%)
 
 # meta targets
 
-.PHONY: all clean data update manifest install
+.PHONY: all clean data update manifest install test_install_uninstall
 
 all: libutf8proc.a libutf8proc.$(SHLIB_EXT)
 
@@ -183,6 +184,9 @@ test/misc: test/misc.c test/tests.o utf8proc.o utf8proc.h test/tests.h
 test/maxdecomposition: test/maxdecomposition.c test/tests.o utf8proc.o utf8proc.h test/tests.h
 	$(CC) $(UCFLAGS) $(LDFLAGS) -DUNICODE_VERSION='"'`$(PERL) -ne "/^UNICODE_VERSION=/ and print $$';" data/Makefile`'"' test/maxdecomposition.c test/tests.o utf8proc.o -o $@
 
+test_install_uninstall: manifest
+	./test/install_uninstall.sh
+
 # make release tarball from master branch
 dist:
 	git archive master --prefix=utf8proc-$(VERSION)/ -o utf8proc-$(VERSION).tar.gz
@@ -198,7 +202,7 @@ distcheck: dist
 	make -C utf8proc-$(VERSION) check
 	rm -rf utf8proc-$(VERSION)
 
-check: test/normtest data/NormalizationTest.txt data/Lowercase.txt data/Uppercase.txt test/graphemetest data/GraphemeBreakTest.txt test/printproperty test/case test/iscase test/custom test/charwidth test/misc test/maxdecomposition test/valid test/iterate bench/bench.c bench/util.c bench/util.h utf8proc.o
+check: test/normtest data/NormalizationTest.txt data/Lowercase.txt data/Uppercase.txt test/graphemetest data/GraphemeBreakTest.txt test/printproperty test/case test/iscase test/custom test/charwidth test/misc test/maxdecomposition test/valid test/iterate bench/bench.c bench/util.c bench/util.h utf8proc.o test_install_uninstall
 	$(MAKE) -C bench
 	test/normtest data/NormalizationTest.txt
 	test/graphemetest data/GraphemeBreakTest.txt

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,15 @@ ifneq ($(OS),Darwin)
 	ln -f -s libutf8proc.$(SHLIB_VERS_EXT) $(DESTDIR)$(libdir)/libutf8proc.so.$(MAJOR)
 endif
 
+uninstall:
+	$(RM) $(DESTDIR)$(includedir)/utf8proc.h
+	$(RM) $(DESTDIR)$(libdir)/libutf8proc.a
+	$(RM) $(DESTDIR)$(libdir)/libutf8proc.$(SHLIB_VERS_EXT) $(DESTDIR)$(libdir)/libutf8proc.$(SHLIB_EXT)
+	$(RM) $(DESTDIR)$(pkgconfigdir)/libutf8proc.pc
+ifneq ($(OS),Darwin)
+	$(RM) $(DESTDIR)$(libdir)/libutf8proc.so.$(MAJOR)
+endif
+
 MANIFEST.new:
 	rm -rf tmp
 	$(MAKE) install prefix=/usr DESTDIR=$(PWD)/tmp

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ VERSION=2.11.3
 
 OS := $(shell uname)
 ifeq ($(OS),Darwin) # MacOS X
-  FIND=gfind
   SHLIB_EXT = dylib
   SHLIB_VERS_EXT = $(MAJOR).dylib
 else # GNU/Linux, at least (Windows should probably use cmake)

--- a/test/install_uninstall.sh
+++ b/test/install_uninstall.sh
@@ -22,7 +22,7 @@ fi
 cut -d ' ' -f 1 MANIFEST.new | while read -r installed_file; do
   [ -d "$install_dir/$installed_file" ] && continue
 	if [ -f "$install_dir/$installed_file" ]; then
-		echo "FAILED: make install of "$installed_file"" >&2
+		echo "FAILED: make uninstall of "$installed_file"" >&2
 		rm -rf "$install_dir"
 		exit 1
 	fi

--- a/test/install_uninstall.sh
+++ b/test/install_uninstall.sh
@@ -6,20 +6,11 @@ if [ -z "$install_dir" ]; then
   exit 1
 fi
 
-# test installation
 if ! make install DESTDIR="$install_dir" prefix=""; then
 	echo "FAILED: make install" >&2
 	rm -rf "$install_dir"
 	exit 1
 fi
-
-cut -d ' ' -f 1 MANIFEST.new | while read -r installed_file; do
-	if [ ! -e "$install_dir/$installed_file" ]; then
-		echo "FAILED: make install of "$installed_file"" >&2
-		rm -rf "$install_dir"
-		exit 1
-	fi
-done
 
 # test uninstallation
 if ! make uninstall DESTDIR="$install_dir" prefix=""; then

--- a/test/install_uninstall.sh
+++ b/test/install_uninstall.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+install_dir=`mktemp -d`
+if [ -z "$install_dir" ]; then
+  echo "install_uninstall error: could not create temporary directory"  >&2
+  exit 1
+fi
+
+# test installation
+if ! make install DESTDIR="$install_dir" prefix=""; then
+	echo "FAILED: make install" >&2
+	rm -rf "$install_dir"
+	exit 1
+fi
+
+cut -d ' ' -f 1 MANIFEST.new | while read -r installed_file; do
+	if [ ! -e "$install_dir/$installed_file" ]; then
+		echo "FAILED: make install of "$installed_file"" >&2
+		rm -rf "$install_dir"
+		exit 1
+	fi
+done
+
+# test uninstallation
+if ! make uninstall DESTDIR="$install_dir" prefix=""; then
+	echo "FAILED: make uninstall" >&2
+	rm -rf "$install_dir"
+	exit 1
+fi
+
+cut -d ' ' -f 1 MANIFEST.new | while read -r installed_file; do
+  [ -d "$install_dir/$installed_file" ] && continue
+	if [ -f "$install_dir/$installed_file" ]; then
+		echo "FAILED: make install of "$installed_file"" >&2
+		rm -rf "$install_dir"
+		exit 1
+	fi
+done
+
+echo "install_uninstall tests SUCCEEDED"


### PR DESCRIPTION
Hi, thanks for the awesome library.

This adds a `make uninstall` target that can be used to uninstall the libraries, utf8proc header, and pkg-config file.

An uninstall target would be useful for [hfsfuse](https://github.com/0x09/hfsfuse) which bundles utf8proc as a subtree and offers the ability to uninstall bundled libraries in its own Makefile.
