### PR TITLE
Add utf8proc::utf8proc alias for utf8proc library for source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library (utf8proc
   utf8proc.c
   utf8proc.h
 )
+add_library(utf8proc::utf8proc ALIAS utf8proc)
 
 # expose header path, for when this is part of a larger cmake project
 target_include_directories(utf8proc PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)


### PR DESCRIPTION
Not having an alias makes such workflow inconsistent from library consumer standpoint:
```cmake
find_package(UTF8Proc CONFIG QUIET)
if (NOT UTF8Proc_FOUND)
    include(FetchContent)
    FetchContent_Declare(
        utf8proc
        GIT_REPOSITORY https://github.com/JuliaStrings/utf8proc
        GIT_TAG e46d2dba26a06f2ec3c57d944c8b679c6d8fea44
    )
    FetchContent_MakeAvailable(utf8proc)
endif ()

target_link_libraries(${PROJECT_NAME} PRIVATE utf8proc::utf8proc)
```
  utf8proc::utf8proc target only exists when it was consumed via find_package, while utf8proc target only works when it's consumed via FetchContent.
  
  This change makes it possible to consistently use utf8proc::utf8proc in both cases